### PR TITLE
Add HTTP2 and Allow Custom Handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-playground/validator/v10 v10.20.0
 	github.com/joho/godotenv v1.5.1
 	go.uber.org/fx v1.21.1
+	golang.org/x/net v0.25.0
 )
 
 require (
@@ -20,7 +21,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
-	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 )

--- a/router.go
+++ b/router.go
@@ -11,11 +11,18 @@ import (
 // Handler is a function that can be used as middleware, or as a route handler.
 type Handler func(*Context) error
 
+// Adding in Handlers
+type ExtraHandler struct {
+	Path    string
+	Handler http.Handler
+}
+
 // Router is a router that can be used to add routes.
 type Router struct {
-	Routes     []*Route
-	Mux        *http.ServeMux
-	Middleware []Handler
+	Routes         []*Route
+	Mux            *http.ServeMux
+	Middleware     []Handler
+	CustomHandlers []ExtraHandler
 }
 
 // NewRouter creates a new router.


### PR DESCRIPTION
Was curious about integrating gRPC with the service this is just a few changes to make possible and then the example:

https://github.com/michaelg100/caesar-start-kit-gprc/tree/main

 for actual testing checked by replacing with local in the start kit. 

replace github.com/caesar-rocks/core => /../local/core

